### PR TITLE
System permissions

### DIFF
--- a/jlh/JonFirstApp/.idea/misc.xml
+++ b/jlh/JonFirstApp/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/MainActivity.java
+++ b/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/MainActivity.java
@@ -2,15 +2,12 @@ package com.e_conomic.jonfirstapp;
 
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
-import android.telephony.SmsManager;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
@@ -55,14 +52,17 @@ public class MainActivity extends FragmentActivity implements MainFragment.MainF
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
 
         if (mainFragment == null) {
             Log.w(MAIN_ACTIVITY_TAG, "Main Fragment is null when trying to update permissions");
             return;
         }
 
-        mainFragment.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        if (requestCode == MainFragment.SEND_SMS_PERMISSION_REQUEST) {
+            mainFragment.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        }
     }
 
     /** Helper method that retrieves references to the fragments used in this activity and sets

--- a/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/MainActivity.java
+++ b/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/MainActivity.java
@@ -2,12 +2,15 @@ package com.e_conomic.jonfirstapp;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
+import android.telephony.SmsManager;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
@@ -18,9 +21,6 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
-
-import static android.Manifest.permission.SEND_SMS;
-
 
 public class MainActivity extends FragmentActivity implements MainFragment.MainFragmentListener {
 
@@ -36,6 +36,7 @@ public class MainActivity extends FragmentActivity implements MainFragment.MainF
 
     // Fragments
     private DisplayMessageFragment displayMessageFragment = null;
+    private MainFragment mainFragment = null;
 
     // Views
     private View displayMessageFragmentContainer = null;
@@ -51,8 +52,17 @@ public class MainActivity extends FragmentActivity implements MainFragment.MainF
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         setupFragments();
-        // Request permission to send SMS.
-        ActivityCompat.requestPermissions(this, new String[]{SEND_SMS}, 1);
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+
+        if (mainFragment == null) {
+            Log.w(MAIN_ACTIVITY_TAG, "Main Fragment is null when trying to update permissions");
+            return;
+        }
+
+        mainFragment.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 
     /** Helper method that retrieves references to the fragments used in this activity and sets
@@ -72,7 +82,7 @@ public class MainActivity extends FragmentActivity implements MainFragment.MainF
 
         FragmentManager fragmentManager = getSupportFragmentManager();
 
-        MainFragment mainFragment = (MainFragment)
+        mainFragment = (MainFragment)
                 fragmentManager.findFragmentById(R.id.fragment_main);
 
         // Find the container that holds the DisplayMessageFragment.

--- a/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/MainActivity.java
+++ b/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/MainActivity.java
@@ -2,6 +2,7 @@ package com.e_conomic.jonfirstapp;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -60,8 +61,13 @@ public class MainActivity extends FragmentActivity implements MainFragment.MainF
             return;
         }
 
-        if (requestCode == MainFragment.SEND_SMS_PERMISSION_REQUEST) {
-            mainFragment.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        switch (requestCode) {
+            case MainFragment.SEND_SMS_PERMISSION_REQUEST: {
+                if (grantResults.length > 0 &&
+                        grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    mainFragment.sendSMS();
+                }
+            }
         }
     }
 

--- a/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/MainFragment.java
+++ b/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/MainFragment.java
@@ -133,7 +133,7 @@ public class MainFragment extends Fragment implements LoaderManager.LoaderCallba
             }
         }
     }
-
+    
     /** Helper method that creates the layout parameters used in this fragment class.*/
     private void setupLayoutParams() {
         recipientViewLayoutParams = new LinearLayout.LayoutParams(
@@ -147,23 +147,7 @@ public class MainFragment extends Fragment implements LoaderManager.LoaderCallba
         sendButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                message = editMessage.getText().toString();
-
-                if (message.length() <= 0) {
-                    EnterMessageDialogFragment dialog = new EnterMessageDialogFragment();
-                    dialog.show(getFragmentManager(), ENTER_MESSAGE_FRAGMENT_TAG);
-                    return;
-                }
-
-                if (contactPhoneNumber == null) {
-                    return;
-                }
-                
-                delegate.sendMessage(message);
-                editMessage.setText("");
-
-                requestSMSPermission();
-
+                sendMessage();
             }
         });
 
@@ -191,20 +175,48 @@ public class MainFragment extends Fragment implements LoaderManager.LoaderCallba
         });
     }
 
-    public void requestSMSPermission() {
+    /** Sends the user entered message if permission was granted. Requests the permission if the app
+     * does not already have it. Also shows a dialog if now message was entered. */
+    private void sendMessage() {
+
+        message = editMessage.getText().toString();
+
+        if (message.length() <= 0) {
+            EnterMessageDialogFragment dialog = new EnterMessageDialogFragment();
+            dialog.show(getFragmentManager(), ENTER_MESSAGE_FRAGMENT_TAG);
+            return;
+        }
+
+        // If the user does not wish to send an SMS.
+        if (contactPhoneNumber == null) {
+            return;
+        }
+
+        delegate.sendMessage(message);
+        editMessage.setText("");
 
         if (ContextCompat.checkSelfPermission(getActivity(), SEND_SMS)
                 != PackageManager.PERMISSION_GRANTED) {
-
+            // SMS permission was not granted. Show explanation or request permission.
             if (ActivityCompat.shouldShowRequestPermissionRationale(getActivity(), SEND_SMS)) {
                 // Show explanation.
                 SMSPermissionExplanationFragment dialog = new SMSPermissionExplanationFragment();
                 dialog.show(getFragmentManager(), SMS_EXPLANATION_FRAGMENT_TAG);
             } else {
                 // Request permission.
-                ActivityCompat.requestPermissions(getActivity(), new String[]{SEND_SMS}, SEND_SMS_PERMISSION_REQUEST);
+                ActivityCompat.requestPermissions(getActivity(),
+                        new String[]{SEND_SMS}, SEND_SMS_PERMISSION_REQUEST);
             }
+        } else {
+            // Permission was granted. Send SMS.
+            sendSMS();
         }
+    }
+
+    /** Sends the user entered message to the chosen contact. */
+    private void sendSMS() {
+        SmsManager smsManager = SmsManager.getDefault();
+        smsManager.sendTextMessage(contactPhoneNumber, null, message, null, null);
     }
 
     /** Sets the text on the show/hide button. */

--- a/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/MainFragment.java
+++ b/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/MainFragment.java
@@ -180,7 +180,7 @@ public class MainFragment extends Fragment implements LoaderManager.LoaderCallba
 
         message = editMessage.getText().toString();
 
-        if (message.length() <= 0) {
+        if (message.isEmpty()) {
             EnterMessageDialogFragment dialog = new EnterMessageDialogFragment();
             dialog.show(getFragmentManager(), ENTER_MESSAGE_FRAGMENT_TAG);
             return;
@@ -189,7 +189,7 @@ public class MainFragment extends Fragment implements LoaderManager.LoaderCallba
         delegate.sendMessage(message);
         editMessage.setText("");
 
-        if (phoneNumberHasNotBeenEntered()) {
+        if (!phoneNumberHasBeenEntered()) {
             return;
         }
 
@@ -212,8 +212,8 @@ public class MainFragment extends Fragment implements LoaderManager.LoaderCallba
     }
 
     /** Checks if the user has added a contact with a phone number. */
-    private boolean phoneNumberHasNotBeenEntered() {
-        return contactPhoneNumber == null;
+    private boolean phoneNumberHasBeenEntered() {
+        return contactPhoneNumber != null;
     }
 
     /** Sets the text on the show/hide button. */

--- a/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/MainFragment.java
+++ b/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/MainFragment.java
@@ -186,13 +186,12 @@ public class MainFragment extends Fragment implements LoaderManager.LoaderCallba
             return;
         }
 
-        // If the user does not wish to send an SMS.
-        if (contactPhoneNumber == null) {
-            return;
-        }
-
         delegate.sendMessage(message);
         editMessage.setText("");
+
+        if (phoneNumberHasNotBeenEntered()) {
+            return;
+        }
 
         if (ContextCompat.checkSelfPermission(getActivity(), SEND_SMS)
                 != PackageManager.PERMISSION_GRANTED) {
@@ -210,6 +209,11 @@ public class MainFragment extends Fragment implements LoaderManager.LoaderCallba
             // Permission was granted. Send SMS.
             sendSMS();
         }
+    }
+
+    /** Checks if the user has added a contact with a phone number. */
+    private boolean phoneNumberHasNotBeenEntered() {
+        return contactPhoneNumber == null;
     }
 
     /** Sets the text on the show/hide button. */
@@ -276,8 +280,8 @@ public class MainFragment extends Fragment implements LoaderManager.LoaderCallba
         data.moveToFirst();
 
         // Get contact information.
-        contactPhoneNumber = data.getString(data.getColumnIndex(Phone.DISPLAY_NAME));
-        contactName = data.getString(data.getColumnIndex(Phone.NUMBER));
+        contactPhoneNumber = data.getString(data.getColumnIndex(Phone.NUMBER));
+        contactName = data.getString(data.getColumnIndex(Phone.DISPLAY_NAME));
 
         setRecipientDetailsView();
     }

--- a/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/MainFragment.java
+++ b/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/MainFragment.java
@@ -7,7 +7,6 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
 import android.provider.ContactsContract;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
@@ -133,7 +132,7 @@ public class MainFragment extends Fragment implements LoaderManager.LoaderCallba
             }
         }
     }
-    
+
     /** Helper method that creates the layout parameters used in this fragment class.*/
     private void setupLayoutParams() {
         recipientViewLayoutParams = new LinearLayout.LayoutParams(
@@ -213,12 +212,6 @@ public class MainFragment extends Fragment implements LoaderManager.LoaderCallba
         }
     }
 
-    /** Sends the user entered message to the chosen contact. */
-    private void sendSMS() {
-        SmsManager smsManager = SmsManager.getDefault();
-        smsManager.sendTextMessage(contactPhoneNumber, null, message, null, null);
-    }
-
     /** Sets the text on the show/hide button. */
     private void setButtonText() {
         if (isDisplayMessageFragmentVisible) {
@@ -246,6 +239,12 @@ public class MainFragment extends Fragment implements LoaderManager.LoaderCallba
         Intent pickContactIntent = new Intent(Intent.ACTION_PICK, Uri.parse("content://contacts"));
         pickContactIntent.setType(Phone.CONTENT_TYPE);
         startActivityForResult(pickContactIntent, PICK_CONTACT_REQUEST);
+    }
+
+    /** Sends the user entered message to the chosen contact. */
+    public void sendSMS() {
+        SmsManager smsManager = SmsManager.getDefault();
+        smsManager.sendTextMessage(contactPhoneNumber, null, message, null, null);
     }
 
     /** Returns true if the fragment that displays the message is visible. */

--- a/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/SMSPermissionExplanationFragment.java
+++ b/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/SMSPermissionExplanationFragment.java
@@ -20,7 +20,8 @@ public class SMSPermissionExplanationFragment extends DialogFragment {
         dialogBuilder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                ActivityCompat.requestPermissions(getActivity(), new String[]{SEND_SMS}, MainFragment.SEND_SMS_PERMISSION_REQUEST);
+                ActivityCompat.requestPermissions(getActivity(),
+                        new String[]{SEND_SMS}, MainFragment.SEND_SMS_PERMISSION_REQUEST);
             }
         });
 

--- a/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/SMSPermissionExplanationFragment.java
+++ b/jlh/JonFirstApp/app/src/main/java/com/e_conomic/jonfirstapp/SMSPermissionExplanationFragment.java
@@ -1,0 +1,29 @@
+package com.e_conomic.jonfirstapp;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.app.DialogFragment;
+import static android.Manifest.permission.SEND_SMS;
+
+public class SMSPermissionExplanationFragment extends DialogFragment {
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(getActivity());
+        dialogBuilder.setMessage(R.string.SMSExplanation);
+        dialogBuilder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                ActivityCompat.requestPermissions(getActivity(), new String[]{SEND_SMS}, MainFragment.SEND_SMS_PERMISSION_REQUEST);
+            }
+        });
+
+        return dialogBuilder.create();
+    }
+}

--- a/jlh/JonFirstApp/app/src/main/res/values-da/strings.xml
+++ b/jlh/JonFirstApp/app/src/main/res/values-da/strings.xml
@@ -15,4 +15,5 @@
     <string name="at_no">" på "</string>
     <string name="enter_message">Venligst indtast en besked</string>
     <string name="ok">OK</string>
+    <string name="SMSExplanation">Du skal give denne app SMS tilladelse for at den kan sende en besked.</string>
 </resources>

--- a/jlh/JonFirstApp/app/src/main/res/values/strings.xml
+++ b/jlh/JonFirstApp/app/src/main/res/values/strings.xml
@@ -14,4 +14,5 @@
     <string name="at_no">" at "</string>
     <string name="enter_message">Please enter a message</string>
     <string name="ok">OK</string>
+    <string name="SMSExplanation">You need to grant this app SMS permission in order for it to send a text message.</string>
 </resources>


### PR DESCRIPTION
On Android 6.0 (API level 23) or higher, the app now requests the SMS permission when the user is trying to send a message instead of when the app is installed (as on 5.1 on lower). Shows a dialog with an explanation when the user denies the permission and then try to send a message.

Both the `SMSPermissionExplanationFragment`and the `MainFragment` calls `ActivityCompat.requestPermissions()` (instead of just `requestPermissions()`) so that both request results returns in the activity's `onRequestPermissionsResult` method.