### PR TITLE
Added simple unit and instrumentation tests

### DIFF
--- a/jlh/WeatherApp/app/build.gradle
+++ b/jlh/WeatherApp/app/build.gradle
@@ -23,9 +23,20 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
+
+    androidTestCompile "com.android.support:support-annotations:$support_version"
+    androidTestCompile "com.android.support.test:rules:0.5"
+    androidTestCompile "com.android.support.test:runner:0.5"
+    androidTestCompile "com.android.support.test.espresso:espresso-core:2.2.2"
+    androidTestCompile("com.android.support.test.espresso:espresso-contrib:2.2.2") {
+        exclude group: 'com.android.support', module: 'appcompat-v7'
+        exclude group: 'com.android.support', module: 'support-v4'
+        exclude group: 'com.android.support', module: 'design'
+        exclude group: 'com.android.support', module: 'recyclerview-v7'
+    }
+
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:2.7.21'
 
     compile "com.android.support:appcompat-v7:$support_version"
     compile "com.android.support:recyclerview-v7:$support_version"

--- a/jlh/WeatherApp/app/src/androidTest/java/com/e_conomic/weatherapp/SimpleInstrumentationTest.kt
+++ b/jlh/WeatherApp/app/src/androidTest/java/com/e_conomic/weatherapp/SimpleInstrumentationTest.kt
@@ -19,12 +19,14 @@ import org.hamcrest.Matchers.`is`
 
 import org.junit.Rule
 import org.junit.Test
+import java.lang.Thread.sleep
 
 class SimpleInstrumentationTest {
 
     @get:Rule val activityRule = ActivityTestRule(MainActivity::class.java)
 
     @Test fun itemClick_navigatesToDetail() {
+        sleep(2000)
         onView(withId(R.id.forecastList)).perform(
                 RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click())
         )

--- a/jlh/WeatherApp/app/src/androidTest/java/com/e_conomic/weatherapp/SimpleInstrumentationTest.kt
+++ b/jlh/WeatherApp/app/src/androidTest/java/com/e_conomic/weatherapp/SimpleInstrumentationTest.kt
@@ -1,0 +1,58 @@
+package com.e_conomic.weatherapp
+
+import com.e_conomic.weatherapp.ui.activities.MainActivity
+import android.support.test.rule.ActivityTestRule
+import android.support.test.espresso.Espresso.*
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.test.espresso.action.ViewActions.click
+import android.support.test.espresso.action.ViewActions.replaceText
+import android.support.test.espresso.contrib.RecyclerViewActions
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.BoundedMatcher
+import android.support.test.espresso.matcher.ViewMatchers.*
+import android.support.v7.widget.RecyclerView
+import android.support.v7.widget.Toolbar
+import android.widget.TextView
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers.`is`
+
+import org.junit.Rule
+import org.junit.Test
+
+class SimpleInstrumentationTest {
+
+    @get:Rule val activityRule = ActivityTestRule(MainActivity::class.java)
+
+    @Test fun itemClick_navigatesToDetail() {
+        onView(withId(R.id.forecastList)).perform(
+                RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click())
+        )
+        onView(withId(R.id.weatherDescription))
+                .check(matches(isAssignableFrom(TextView::class.java)))
+    }
+
+    @Test fun modifyCityId_changesToolbarTitle() {
+        openActionBarOverflowOrOptionsMenu(activityRule.activity)
+        onView(withText(R.string.settings)).perform(click())
+        onView(withId(R.id.settingsCityId)).perform(replaceText("2610613"))
+        pressBack()
+        onView(isAssignableFrom(Toolbar::class.java)).check(matches(
+                withToolbarTitle(`is`("Vejle (DK)"))
+        ))
+    }
+
+    private fun withToolbarTitle(textMatcher: Matcher<CharSequence>): Matcher<Any> =
+            object : BoundedMatcher<Any, Toolbar>(Toolbar::class.java) {
+
+                override fun matchesSafely(toolbar: Toolbar): Boolean {
+                    return textMatcher.matches(toolbar.title)
+                }
+
+                override fun describeTo(description: Description) {
+                    description.appendText("with toolbar title: ")
+                    textMatcher.describeTo(description)
+                }
+
+            }
+}

--- a/jlh/WeatherApp/app/src/main/java/com/e_conomic/weatherapp/extensions/ExtensionUtils.kt
+++ b/jlh/WeatherApp/app/src/main/java/com/e_conomic/weatherapp/extensions/ExtensionUtils.kt
@@ -5,8 +5,8 @@ import android.support.v4.content.ContextCompat
 import java.text.DateFormat
 import java.util.*
 
-fun Long.toDateString(dateFormat: Int = DateFormat.MEDIUM): String {
-    val df = DateFormat.getDateInstance(dateFormat, Locale.getDefault())
+fun Long.toDateString(dateFormat: Int = DateFormat.MEDIUM, locale: Locale = Locale.getDefault()): String {
+    val df = DateFormat.getDateInstance(dateFormat, locale)
     return df.format(this * 1000)
 }
 

--- a/jlh/WeatherApp/app/src/test/java/com/e_conomic/weatherapp/ExtensionsTest.kt
+++ b/jlh/WeatherApp/app/src/test/java/com/e_conomic/weatherapp/ExtensionsTest.kt
@@ -1,19 +1,19 @@
 package com.e_conomic.weatherapp
 
-import com.e_conomic.weatherapp.extensions.Preference
 import com.e_conomic.weatherapp.extensions.toDateString
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.text.DateFormat
+import java.util.*
 
 class ExtensionsTest {
 
     @Test fun testLongToDateString() {
-        assertEquals("Oct 19, 2015", 1445275635L.toDateString())
+        assertEquals("Oct 19, 2015", 1445275635L.toDateString(locale = Locale("en", "US")))
     }
 
     @Test fun testDateStringFullFormat() {
-        assertEquals("Monday, October 19, 2015", 1445275635L.toDateString(DateFormat.FULL))
+        assertEquals("Monday, October 19, 2015", 1445275635L.toDateString(DateFormat.FULL, locale = Locale("en", "US")))
     }
 
 }

--- a/jlh/WeatherApp/app/src/test/java/com/e_conomic/weatherapp/ExtensionsTest.kt
+++ b/jlh/WeatherApp/app/src/test/java/com/e_conomic/weatherapp/ExtensionsTest.kt
@@ -1,0 +1,19 @@
+package com.e_conomic.weatherapp
+
+import com.e_conomic.weatherapp.extensions.Preference
+import com.e_conomic.weatherapp.extensions.toDateString
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.text.DateFormat
+
+class ExtensionsTest {
+
+    @Test fun testLongToDateString() {
+        assertEquals("Oct 19, 2015", 1445275635L.toDateString())
+    }
+
+    @Test fun testDateStringFullFormat() {
+        assertEquals("Monday, October 19, 2015", 1445275635L.toDateString(DateFormat.FULL))
+    }
+
+}

--- a/jlh/WeatherApp/app/src/test/java/com/e_conomic/weatherapp/ForecastDataMapperTest.kt
+++ b/jlh/WeatherApp/app/src/test/java/com/e_conomic/weatherapp/ForecastDataMapperTest.kt
@@ -17,46 +17,46 @@ class ForecastDataMapperTest {
         `when`(request.execute()).thenReturn(
                 ForecastResult(
                         City(
-                                0L, //cityId
-                                "Copenhagen", //name
-                                Coordinates(0f, 0f),
-                                "Denmark", //country
-                                1 //population
+                                id = 0L,
+                                name = "Copenhagen",
+                                coord = Coordinates(0f, 0f),
+                                country = "Denmark",
+                                population = 1
                         ),
                         listOf(Forecast(
-                                123L, //date
-                                Temperature(
-                                        0f, //day
-                                        -5f, //min
-                                        10f, //max
-                                        0f, //night
-                                        0f, //eve
-                                        0f //morn
+                                dt = 123L,
+                                temp = Temperature(
+                                        day = 0f,
+                                        min = -5f,
+                                        max = 10f,
+                                        night = 0f,
+                                        eve = 0f,
+                                        morn = 0f
                                 ),
-                                0f, //pressure
-                                0, //humidity
-                                listOf(Weather(
-                                        0L, //id
-                                        "weatherMain",
-                                        "weatherDescription",
-                                        "weatherIcon"
+                                pressure = 0f,
+                                humidity = 0,
+                                weather = listOf(Weather(
+                                        id = 0L, //id
+                                        main = "weatherMain",
+                                        description = "weatherDescription",
+                                        icon = "weatherIcon"
                                 )),
-                                0f, //speed
-                                0, //degrees
-                                0, //clouds
-                                0f //rain
+                                speed = 0f,
+                                deg = 0,
+                                clouds = 0,
+                                rain = 0f
                         )))
         )
 
         val expectedResult = ForecastList(
-                "Copenhagen",
-                "Denmark",
-                listOf(modelForecast(
-                        123L, //date
-                        "weatherDescription",
-                        10, //high
-                        -5, //low
-                        "http://openweathermap.org/img/w/weatherIcon.png"
+                city = "Copenhagen",
+                country = "Denmark",
+                dailyForecast = listOf(modelForecast(
+                        date = 123L,
+                        description = "weatherDescription",
+                        high = 10,
+                        low = -5,
+                        iconUrl = "http://openweathermap.org/img/w/weatherIcon.png"
                 ))
         )
 

--- a/jlh/WeatherApp/app/src/test/java/com/e_conomic/weatherapp/ForecastDataMapperTest.kt
+++ b/jlh/WeatherApp/app/src/test/java/com/e_conomic/weatherapp/ForecastDataMapperTest.kt
@@ -1,0 +1,66 @@
+package com.e_conomic.weatherapp
+
+import com.e_conomic.weatherapp.data.*
+import com.e_conomic.weatherapp.domain.mappers.ForecastDataMapper
+import com.e_conomic.weatherapp.domain.model.ForecastList
+import org.junit.Assert.assertEquals
+import com.e_conomic.weatherapp.domain.model.Forecast as modelForecast
+import org.junit.Test
+
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+
+class ForecastDataMapperTest {
+
+    @Test fun testCorrectMappingToModel() {
+        val request = mock(ForecastRequest::class.java)
+        `when`(request.execute()).thenReturn(
+                ForecastResult(
+                        City(
+                                0L, //cityId
+                                "Copenhagen", //name
+                                Coordinates(0f, 0f),
+                                "Denmark", //country
+                                1 //population
+                        ),
+                        listOf(Forecast(
+                                123L, //date
+                                Temperature(
+                                        0f, //day
+                                        -5f, //min
+                                        10f, //max
+                                        0f, //night
+                                        0f, //eve
+                                        0f //morn
+                                ),
+                                0f, //pressure
+                                0, //humidity
+                                listOf(Weather(
+                                        0L, //id
+                                        "weatherMain",
+                                        "weatherDescription",
+                                        "weatherIcon"
+                                )),
+                                0f, //speed
+                                0, //degrees
+                                0, //clouds
+                                0f //rain
+                        )))
+        )
+
+        val expectedResult = ForecastList(
+                "Copenhagen",
+                "Denmark",
+                listOf(modelForecast(
+                        123L, //date
+                        "weatherDescription",
+                        10, //high
+                        -5, //low
+                        "http://openweathermap.org/img/w/weatherIcon.png"
+                ))
+        )
+
+        assertEquals(ForecastDataMapper().convertToForecastModel(request.execute()),
+                expectedResult)
+    }
+}

--- a/jlh/WeatherApp/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/jlh/WeatherApp/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/jlh/WeatherApp/build.gradle
+++ b/jlh/WeatherApp/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Added a few simple tests (do you want me to create more?). I didn't dive deep into every aspect of 
 `Espresso`, but tried to get a feeling for how it worked in general. 

In unit tests there a a few very simple tests that tests the `toDateString` extension method and one that tests that the `ForecastDataMapper` maps the values correctly. 

The first instrumentation test checks that a `DetailActivity` with a correct `textView` is opened when the first list item is clicked. The other opens the `SettingsActivity` through the toolbar and changes the `cityId` to Vejle (2610613) and then returns to the main screen and checks whether the toolbar title was updated correctly.